### PR TITLE
Add retry support

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -37,7 +37,7 @@ library
   import:               base, project-config
                       , maybe-Win32-network
   hs-source-dirs:       src
-  build-depends:        aeson             >= 1.5.6.0
+  build-depends:        aeson             >= 1.5.6.0 && < 2.0.0.0
                       , aeson-pretty      >= 0.8.5
                       , async
                       , bytestring


### PR DESCRIPTION
This combinator is will allow tests to retry a specified number of times before failing which will help with flaky tests.

See https://github.com/input-output-hk/cardano-node/pull/3538 for example.
