### PR TITLE
Update to support aeson >= 2.0.0

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   hedgehog-extras
-version:                0.1.0.0
+version:                0.2.0.0
 synopsis:               Supplemental library for hedgehog
 description:            Supplemental library for hedgehog.
 category:               Test
@@ -37,7 +37,7 @@ library
   import:               base, project-config
                       , maybe-Win32-network
   hs-source-dirs:       src
-  build-depends:        aeson             >= 1.5.6.0 && < 2.0.0.0
+  build-depends:        aeson             >= 2.0.0
                       , aeson-pretty      >= 0.8.5
                       , async
                       , bytestring

--- a/src/Hedgehog/Extras/Stock/Aeson.hs
+++ b/src/Hedgehog/Extras/Stock/Aeson.hs
@@ -3,12 +3,14 @@ module Hedgehog.Extras.Stock.Aeson
   ) where
 
 import           Data.Aeson
+import qualified Data.Aeson.KeyMap as KM
 import           Data.HashMap.Lazy
 import           Data.Text
+import           Prelude ((.), ($))
 
 -- | Rewrite a JSON object to another JSON object using the function 'f'.
 --
 -- All other JSON values are preserved.
 rewriteObject :: (HashMap Text Value -> HashMap Text Value) -> Value -> Value
-rewriteObject f (Object hm) = Object (f hm)
+rewriteObject f (Object hm) = Object (KM.fromHashMapText . f . KM.toHashMapText $ hm)
 rewriteObject _ v = v


### PR DESCRIPTION
Bump the version number here accordingly. `rewriteObject` could now
probably take a nicer interface, but we retain the old one for
compatiblity.