### PR TITLE
New rewriteArrayElements function

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,8 +21,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.4"]
+        ghc: ["8.6.5", "8.10.7"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        aeson: ["2.0.3.0"]
+        include:
+          - ghc: "8.10.7"
+            os: ubuntu-latest
+            aeson: "1.5.6.0"
 
     steps:
       - uses: actions/checkout@v2
@@ -39,7 +44,7 @@ jobs:
           echo "CACHE_VERSION=3oqhaby"                  >> $GITHUB_ENV
 
       - name: Configure project
-        run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+
+        run: cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+ --constraint="aeson == ${{ matrix.aeson }}"
 
       - name: Record dependencies
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -5,3 +5,9 @@ source-repository-package
   location: https://github.com/input-output-hk/Win32-network
   tag: 82f4afb8c240b8446a1db6c6b50901a42028ce0f
   --sha256: 1ggm3239z41z0ca9al43v9y2wmf20bbmdgj1k27kyph54gqkdbhn
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-works/hw-aeson
+  tag: 6dc309ff4260c71d9a18c220cbae8aa1dfe2a02e
+  --sha256: 0i0f7rnbr49rk59fzap9433b00hklgiq26aq9vqgmw9dmafv43i3

--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -37,7 +37,7 @@ library
   import:               base, project-config
                       , maybe-Win32-network
   hs-source-dirs:       src
-  build-depends:        aeson             >= 2.0.0
+  build-depends:        aeson             >= 1.5.6.0
                       , aeson-pretty      >= 0.8.5
                       , async
                       , bytestring
@@ -46,6 +46,7 @@ library
                       , exceptions
                       , filepath
                       , hedgehog
+                      , hw-aeson          >= 0.1.5.0
                       , mmorph
                       , mtl
                       , network

--- a/src/Hedgehog/Extras/Stock/Aeson.hs
+++ b/src/Hedgehog/Extras/Stock/Aeson.hs
@@ -1,9 +1,11 @@
 module Hedgehog.Extras.Stock.Aeson
   ( rewriteObject
+  , rewriteArrayElements
   ) where
 
 import           Data.Aeson
 import qualified Data.Aeson.KeyMap as KM
+import           Data.Functor
 import           Data.HashMap.Lazy
 import           Data.Text
 import           Prelude ((.), ($))
@@ -14,3 +16,10 @@ import           Prelude ((.), ($))
 rewriteObject :: (HashMap Text Value -> HashMap Text Value) -> Value -> Value
 rewriteObject f (Object hm) = Object (KM.fromHashMapText . f . KM.toHashMapText $ hm)
 rewriteObject _ v = v
+
+-- | Rewrite each element of a JSON array using the function 'f'.
+--
+-- All other JSON values are preserved.
+rewriteArrayElements :: (Value -> Value) -> Value -> Value
+rewriteArrayElements f (Array hm) = Array (fmap f hm)
+rewriteArrayElements _ v = v

--- a/src/Hedgehog/Extras/Stock/Aeson.hs
+++ b/src/Hedgehog/Extras/Stock/Aeson.hs
@@ -4,11 +4,12 @@ module Hedgehog.Extras.Stock.Aeson
   ) where
 
 import           Data.Aeson
-import qualified Data.Aeson.KeyMap as KM
 import           Data.Functor
 import           Data.HashMap.Lazy
 import           Data.Text
 import           Prelude ((.), ($))
+
+import qualified HaskellWorks.Data.Aeson.Compat.Map as KM
 
 -- | Rewrite a JSON object to another JSON object using the function 'f'.
 --


### PR DESCRIPTION
The `rewriteArrayElements` can be used to rewrite `configuration.yaml` in test code.

For example we do something similar with `rewriteObject` [here](https://github.com/input-output-hk/cardano-node/blob/2b1d18c6c7b7142d9eebfec34da48840ed4409b6/cardano-testnet/src/Testnet/Cardano.hs#L244).