### PR TITLE
Don't create an intermediate workspace directory

### DIFF
--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -141,9 +141,7 @@ workspace :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> (FilePath -> 
 workspace prefixPath f = GHC.withFrozenCallStack $ do
   systemTemp <- H.evalIO IO.getCanonicalTemporaryDirectory
   maybeKeepWorkspace <- H.evalIO $ IO.lookupEnv "KEEP_WORKSPACE"
-  let systemPrefixPath = systemTemp <> "/" <> prefixPath
-  H.evalIO $ IO.createDirectoryIfMissing True systemPrefixPath
-  ws <- H.evalIO $ IO.createTempDirectory systemPrefixPath "test"
+  ws <- H.evalIO $ IO.createTempDirectory systemTemp $ prefixPath <> "-test"
   H.annotate $ "Workspace: " <> ws
   liftIO $ IO.writeFile (ws <> "/module") callerModuleName
   f ws
@@ -353,7 +351,7 @@ byDeadlineM period deadline errorMessage f = GHC.withFrozenCallStack $ do
               H.annotateShow currentTime
               void $ failMessage GHC.callStack $ "Condition not met by deadline: " <> errorMessage
               H.throwAssertion e
- 
+
 -- | Run the operation 'f' once a second until it returns 'True' or the duration expires.
 --
 -- Expiration of the duration results in an assertion failure


### PR DESCRIPTION
This skips creating the intermediate prefix folder, so `workspace "somedir" f` will create `$TMPDIR/somedir-test-$random` instead of `$TMPDIR/somedir/test-$random`. This fixes a "permission denied" error when multiple users use the same prefix: a folder created by one won't be accessible by the other.