### PR TITLE
Fix moduleWorkspace

### DIFF
--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -156,10 +156,12 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
 --
 -- The directory will be deleted if the block succeeds, but left behind if
 -- the block fails.
-moduleWorkspace :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> (FilePath -> m ()) -> m ()
-moduleWorkspace prefixPath f = GHC.withFrozenCallStack $ do
+--
+-- The 'prefix' argument should not contain directory delimeters.
+moduleWorkspace :: (MonadTest m, MonadIO m, HasCallStack) => String -> (FilePath -> m ()) -> m ()
+moduleWorkspace prefix f = GHC.withFrozenCallStack $ do
   let srcModule = maybe "UnknownModule" (GHC.srcLocModule . snd) (listToMaybe (GHC.getCallStack GHC.callStack))
-  workspace (prefixPath <> "/" <> srcModule) f
+  workspace (prefix <> "-" <> srcModule) f
 
 -- | Annotate the given string at the context supplied by the callstack.
 noteWithCallstack :: MonadTest m => CallStack -> String -> m ()


### PR DESCRIPTION
Fixes this bug:

```
✗ prop_createVRFSigningKeyFilePermissions failed at test/Test/Cli/FilePermissions.hs:22:20
    after 1 test.
    shrink path: 1:
  
       ┏━━ test/Test/Cli/FilePermissions.hs ━━━
    20 ┃ prop_createVRFSigningKeyFilePermissions :: Property
    21 ┃ prop_createVRFSigningKeyFilePermissions =
    22 ┃   H.propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
       ┃   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       ┃   │ ━━━ Exception (IOException) ━━━
       ┃   │ /Users/runner/work/_temp/tmp/Test.Cli.FilePermissions-test-baec7ace40[79](https://github.com/input-output-hk/cardano-node/actions/runs/3870328906/jobs/6597161958#step:18:80)ea5b: createDirectory: does not exist (No such file or directory)
    23 ┃     -- Key filepaths
    24 ┃     vrfVerKey <- H.noteTempFile tempDir "VRF-verification-key-file"
    25 ┃ 
    26 ┃     vrfSignKey <- H.noteTempFile tempDir "VRF-signing-key-file"
    27 ┃ 
    28 ┃     -- Create VRF key pair
    29 ┃     void $ execCardanoCLI
    30 ┃       [ "node", "key-gen-VRF"
    31 ┃       , "--verification-key-file", vrfVerKey
    32 ┃       , "--signing-key-file", vrfSignKey
    33 ┃       ]
    34 ┃ 
    35 ┃     result <- liftIO . runExceptT $ checkVRFFilePermissions vrfSignKey
    36 ┃     case result of
    37 ┃       Left err ->
    38 ┃         failWith Nothing
    39 ┃           $ "key-gen-VRF cli command created a VRF signing key \
    40 ┃             \file with the wrong permissions: " <> show err
    41 ┃       Right () -> success
  
    This failure can be reproduced by running:
    > recheckAt (Seed 159587631656[80](https://github.com/input-output-hk/cardano-node/actions/runs/3870328906/jobs/6597161958#step:18:81)610442 89577352127[83](https://github.com/input-output-hk/cardano-node/actions/runs/3870328906/jobs/6597161958#step:18:84)8047[85](https://github.com/input-output-hk/cardano-node/actions/runs/3870328906/jobs/6597161958#step:18:86)) "1:" prop_createVRFSigningKeyFilePermissions
```

Which was introduced in https://github.com/input-output-hk/hedgehog-extras/pull/18