### PR TITLE
Add extra assertion functions, fix readM to show correct line

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   hedgehog-extras
-version:                0.4.3.0
+version:                0.4.4.0
 synopsis:               Supplemental library for hedgehog
 description:            Supplemental library for hedgehog.
 category:               Test

--- a/src/Hedgehog/Extras/Stock/String.hs
+++ b/src/Hedgehog/Extras/Stock/String.hs
@@ -2,11 +2,13 @@ module Hedgehog.Extras.Stock.String
   ( strip
   , lastLine
   , firstLine
-  , readM
+  , readNoteM
   ) where
 
 import           Control.Monad.Catch (MonadCatch)
+import           Data.Bifunctor
 import           Data.Function
+import           Data.Semigroup
 import           Data.String
 import           GHC.Stack
 import           Text.Read
@@ -17,7 +19,7 @@ import qualified Data.Text as T
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 
--- | Strip whitepsace from the beginning and end of the string.
+-- | Strip whitespace from the beginning and end of the string.
 strip :: String -> String
 strip = T.unpack . T.strip . T.pack
 
@@ -29,6 +31,13 @@ lastLine = strip . L.unlines . L.reverse . L.take 1 . L.reverse . L.lines
 firstLine :: String -> String
 firstLine = strip . L.unlines . L.take 1 . L.lines
 
--- | Trim leading and trailing whitespace and read the string into a value
-readM :: (Read a, Show a, H.MonadTest m, MonadCatch m, HasCallStack) => String -> m a
-readM = withFrozenCallStack . H.noteShowM . H.evalEither . readEither . strip
+-- | Trim leading and trailing whitespace and read the string into a value. Report the read value in the test
+-- annotations.
+readNoteM :: (Read a, Show a, H.MonadTest m, MonadCatch m, HasCallStack) => String -> m a
+readNoteM inputStr =
+  withFrozenCallStack
+  $ H.noteShowM
+  . H.evalEither
+  . first (<> ": " <> inputStr)
+  . readEither
+  $ strip inputStr

--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -52,6 +52,8 @@ module Hedgehog.Extras.Test.Base
   , assertByDeadlineIO
   , assertByDeadlineMFinally
   , assertByDeadlineIOFinally
+  , assertWith
+  , assertWithM
   , assertM
   , assertIO
   , assertWithinTolerance
@@ -452,6 +454,20 @@ assertByDeadlineMFinally deadline f g = GHC.withFrozenCallStack $ do
         H.annotateShow currentTime
         g
         failMessage GHC.callStack "Condition not met by deadline"
+
+-- | Run the test function against the value. Report the value on the failure.
+assertWith :: (H.MonadTest m, Show p, HasCallStack) => p -> (p -> Bool) -> m ()
+assertWith v f = GHC.withFrozenCallStack $ assertWithM v (pure . f)
+
+-- | Run the test function against the value. Report the value on the failure.
+assertWithM :: (H.MonadTest m, Show p, HasCallStack) => p -> (p -> m Bool) -> m ()
+assertWithM v f = GHC.withFrozenCallStack $ do
+  result <- f v
+  if result
+     then H.success
+     else do
+       noteShow_ v
+       H.assert result
 
 -- | Run the monadic action 'f' and assert the return value is 'True'.
 assertM :: (MonadTest m, HasCallStack) => m Bool -> m ()


### PR DESCRIPTION
This PR:
1. fixes `readM` to correctly report line number and includes original text in the parse error
2. `readM` renamed into `readNoteM`  to indicate that it dumps the value into annotations
3. adds two utility functions `assertWith` and `assertWithM`