### PR TITLE
Create new process groups for newly spawned processes

### DIFF
--- a/src/Hedgehog/Extras/Test/Process.hs
+++ b/src/Hedgehog/Extras/Test/Process.hs
@@ -332,6 +332,8 @@ procFlex' execConfig pkg binaryEnv arguments = GHC.withFrozenCallStack . H.evalM
   return (IO.proc bin arguments)
     { IO.env = getLast $ execConfigEnv execConfig
     , IO.cwd = getLast $ execConfigCwd execConfig
+    -- this allows sending signals to the created processes, without killing the test-suite process
+    , IO.create_group = True
     }
 
 -- | Compute the project base.  This will be based on either the "CARDANO_NODE_SRC"


### PR DESCRIPTION
This changes how processes are created in the test cases. Previously they belonged to the same process group as the test runner, which disallowed sending signals to just spawned processes. If someone sent SIGINT to the testnet process, it would also send SIGINT to the running test case, stopping it instantly.

After this change it's possible to send signals to spawned processes independently. 