### PR TITLE
Add upper bound to tar

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -34,7 +34,7 @@ common network                      { build-depends: network                    
 common process                      { build-depends: process                                                      }
 common resourcet                    { build-depends: resourcet                                                    }
 common stm                          { build-depends: stm                                                          }
-common tar                          { build-depends: tar                                                          }
+common tar                          { build-depends: tar                              <  0.6                      }
 common temporary                    { build-depends: temporary                                                    }
 common text                         { build-depends: text                                                         }
 common time                         { build-depends: time                             >= 1.9.1                    }


### PR DESCRIPTION
Version `0.6` introduced a breaking change to `checkTarbomb` which we rely on so we need to adjust the upper bounds so that this still compiles.