### PR TITLE
Restrict tar

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,4 @@
 packages: .
+
+index-state:
+  , hackage.haskell.org 2023-12-14T23:57:38Z

--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -34,7 +34,7 @@ common network                      { build-depends: network                    
 common process                      { build-depends: process                                                      }
 common resourcet                    { build-depends: resourcet                                                    }
 common stm                          { build-depends: stm                                                          }
-common tar                          { build-depends: tar                                                          }
+common tar                          { build-depends: tar                              == 0.5.1.1                  }
 common temporary                    { build-depends: temporary                                                    }
 common text                         { build-depends: text                                                         }
 common time                         { build-depends: time                             >= 1.9.1                    }


### PR DESCRIPTION
Fixes:

```
src/Hedgehog/Extras/Test/Network.hs:115:40: error: [GHC-83865]
    • Couldn't match type ‘[ghc-prim-0.10.0:GHC.Types.Char]’
                     with ‘tar-0.6.0.0:tar-internal:Codec.Archive.Tar.Types.TarPath’
      Expected: TAR.Entries TAR.FormatError
                -> TAR.Entries (Either TAR.FormatError TAR.TarBombError)
        Actual: TAR.Entries TAR.FormatError
                -> TAR.GenEntries
                     FilePath
                     FilePath
                     (Either
                        (Either TAR.FormatError TAR.DecodeLongNamesError) TAR.TarBombError)
    • In the first argument of ‘(.)’, namely ‘TAR.checkTarbomb topDir’
      In the second argument of ‘(.)’, namely
        ‘TAR.checkTarbomb topDir . TAR.read . GZ.decompress’
      In the first argument of ‘(<$>)’, namely
        ‘tarErrors . TAR.checkTarbomb topDir . TAR.read . GZ.decompress’
    |
115 |       errors <- H.evalIO $ tarErrors . TAR.checkTarbomb topDir . TAR.read . GZ.decompress <$> LBS.readFile tarPath
```