### PR TITLE
Add exec variant that allows a negative call

### DIFF
--- a/src/Hedgehog/Extras/Test/Process.hs
+++ b/src/Hedgehog/Extras/Test/Process.hs
@@ -44,7 +44,7 @@ import           Hedgehog (MonadTest)
 import           Hedgehog.Extras.Internal.Cli (argQuote)
 import           Hedgehog.Extras.Internal.Plan (Component (..), Plan (..))
 import           Hedgehog.Extras.Stock.IO.Process (TimedOut (..))
-import           Prelude (error)
+import           Prelude (error, (++))
 import           System.Exit (ExitCode)
 import           System.FilePath (takeDirectory)
 import           System.FilePath.Posix ((</>))
@@ -173,16 +173,12 @@ execFlex' execConfig pkgBin envBin arguments = GHC.withFrozenCallStack $ do
   case exitResult of
     IO.ExitFailure exitCode -> do
       H.annotate $ L.unlines $
-        [ "Process exited with non-zero exit-code"
+        [ "Process exited with non-zero exit-code: " ++ show @Int exitCode
         , "━━━━ command ━━━━"
         , pkgBin <> " " <> L.unwords (fmap argQuote arguments)
-        , "━━━━ stdout ━━━━"
-        , stdout
-        , "━━━━ stderr ━━━━"
-        , stderr
-        , "━━━━ exit code ━━━━"
-        , show @Int exitCode
         ]
+        ++ if L.null stdout then [] else ["━━━━ stdout ━━━━" , stdout]
+        ++ if L.null stderr then [] else ["━━━━ stderr ━━━━" , stderr]
       H.failMessage GHC.callStack "Execute process failed"
     IO.ExitSuccess -> return stdout
 
@@ -208,16 +204,12 @@ exec execConfig bin arguments = GHC.withFrozenCallStack $ do
   (exitResult, stdout, stderr) <- execAny execConfig bin arguments
   case exitResult of
     IO.ExitFailure exitCode -> H.failMessage GHC.callStack . L.unlines $
-      [ "Process exited with non-zero exit-code"
+      [ "Process exited with non-zero exit-code: " ++ show @Int exitCode
       , "━━━━ command ━━━━"
       , bin <> " " <> L.unwords (fmap argQuote arguments)
-      , "━━━━ stdout ━━━━"
-      , stdout
-      , "━━━━ stderr ━━━━"
-      , stderr
-      , "━━━━ exit code ━━━━"
-      , show @Int exitCode
       ]
+      ++ if L.null stdout then [] else ["━━━━ stdout ━━━━" , stdout]
+      ++ if L.null stderr then [] else ["━━━━ stderr ━━━━" , stderr]
     IO.ExitSuccess -> return stdout
 
 -- | Execute a process, returning the error code, the stdout, and the stderr.

--- a/src/Hedgehog/Extras/Test/Process.hs
+++ b/src/Hedgehog/Extras/Test/Process.hs
@@ -185,10 +185,10 @@ execFlex' execConfig pkgBin envBin arguments = GHC.withFrozenCallStack $ do
 execFlexAny'
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => ExecConfig
-  -> String
-  -> String
+  -> String -- ^ @pkgBin@: name of the binary to launch via 'cabal exec'
+  -> String -- ^ @envBin@: environment variable defining the binary to launch the process, when in Nix
   -> [String]
-  -> m (ExitCode, String, String)
+  -> m (ExitCode, String, String) -- ^ exit code, stdout, stderr
 execFlexAny' execConfig pkgBin envBin arguments = GHC.withFrozenCallStack $ do
   cp <- procFlex' execConfig pkgBin envBin arguments
   H.annotate . ("Command: " <>) $ case IO.cmdspec cp of
@@ -230,9 +230,9 @@ exec execConfig bin arguments = GHC.withFrozenCallStack $ do
 execAny
   :: (MonadTest m, MonadIO m, HasCallStack)
   => ExecConfig
-  -> String
-  -> [String]
-  -> m (ExitCode, String, String)
+  -> String -- ^ The binary to launch
+  -> [String] -- ^ The binary's arguments
+  -> m (ExitCode, String, String) -- ^ exit code, stdout, stderr
 execAny execConfig bin arguments = GHC.withFrozenCallStack $ do
   let cp = (IO.proc bin arguments)
         { IO.env = getLast $ execConfigEnv execConfig


### PR DESCRIPTION
## Description

Right now, all functions in `Process.hs` assume that the call will succeed: they fail the test if the call fails.

This PR adds new variants that do not make this assumption, allowing callers to execute processes that will fail, and handle the exit code, stdout, and stderr themselves.

## Context

Needed for https://github.com/IntersectMBO/cardano-node/pull/5634