### PR TITLE
Add tests to ensure a directory does/doesn't exist (`assertDirectoryExists` and `assertDirectoryMissing`)

### DIFF
--- a/src/Hedgehog/Extras/Test/File.hs
+++ b/src/Hedgehog/Extras/Test/File.hs
@@ -338,6 +338,12 @@ appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
   let delay = DTC.diffUTCTime baseTime offsetTime
   appendFile filePath $ show @DTC.NominalDiffTime delay <> "\n"
 
+-- | Asserts that the given directory exists.
+assertDirectoryExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
+assertDirectoryExists dir = GHC.withFrozenCallStack $ do
+  exists <- H.evalIO $ IO.doesDirectoryExist dir
+  unless exists $ H.failWithCustom GHC.callStack Nothing (dir <> " has not been successfully created.")
+
 -- | Asserts that the given directory is missing.
 assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryMissing dir = GHC.withFrozenCallStack $ do

--- a/src/Hedgehog/Extras/Test/File.hs
+++ b/src/Hedgehog/Extras/Test/File.hs
@@ -342,10 +342,10 @@ appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
 assertDirectoryExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryExists dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  unless exists $ H.failWithCustom GHC.callStack Nothing (dir <> " has not been successfully created.")
+  unless exists $ H.failWithCustom GHC.callStack Nothing ("Directory " <> dir <> " does  exist on the file system.")
 
 -- | Asserts that the given directory is missing.
 assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryMissing dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  when exists $ H.failWithCustom GHC.callStack Nothing (dir <> " should not have been created.")
+  when exists $ H.failWithCustom GHC.callStack Nothing ("Directory " <> dir <> " does not exist on the file system.")

--- a/src/Hedgehog/Extras/Test/File.hs
+++ b/src/Hedgehog/Extras/Test/File.hs
@@ -342,10 +342,10 @@ appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
 assertDirectoryExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryExists dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  unless exists $ H.failWithCustom GHC.callStack Nothing ("Directory " <> dir <> " does  exist on the file system.")
+  unless exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does exist on the file system.")
 
 -- | Asserts that the given directory is missing.
 assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryMissing dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  when exists $ H.failWithCustom GHC.callStack Nothing ("Directory " <> dir <> " does not exist on the file system.")
+  when exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does not exist on the file system.")

--- a/src/Hedgehog/Extras/Test/File.hs
+++ b/src/Hedgehog/Extras/Test/File.hs
@@ -342,10 +342,10 @@ appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
 assertDirectoryExists :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryExists dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  unless exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does exist on the file system.")
+  unless exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does not exist on the file system.")
 
 -- | Asserts that the given directory is missing.
 assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
 assertDirectoryMissing dir = GHC.withFrozenCallStack $ do
   exists <- H.evalIO $ IO.doesDirectoryExist dir
-  when exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does not exist on the file system.")
+  when exists $ H.failWithCustom GHC.callStack Nothing ("Directory '" <> dir <> "' does exist on the file system.")

--- a/src/Hedgehog/Extras/Test/File.hs
+++ b/src/Hedgehog/Extras/Test/File.hs
@@ -47,6 +47,7 @@ module Hedgehog.Extras.Test.File
   , assertEndsWithSingleNewline
 
   , appendFileTimeDelta
+  , assertDirectoryMissing
   ) where
 
 import           Control.Applicative (Applicative (..))
@@ -336,3 +337,9 @@ appendFileTimeDelta filePath offsetTime = GHC.withFrozenCallStack $ do
   baseTime <- H.noteShowIO DTC.getCurrentTime
   let delay = DTC.diffUTCTime baseTime offsetTime
   appendFile filePath $ show @DTC.NominalDiffTime delay <> "\n"
+
+-- | Asserts that the given directory is missing.
+assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
+assertDirectoryMissing dir = GHC.withFrozenCallStack $ do
+  exists <- H.evalIO $ IO.doesDirectoryExist dir
+  when exists $ H.failWithCustom GHC.callStack Nothing (dir <> " should not have been created.")


### PR DESCRIPTION
This PR adds two functions to test about directories:
- `assertDirectoryExists` based on `assertFileExists` that tests that a directory was created.
- `assertDirectoryMissing` based on `assertFileMissing` that tests that a directory wasn't created.