### PR TITLE
Use removePathForcibly to remove directories

### DIFF
--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -154,10 +154,10 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
   maybeKeepWorkspace <- H.evalIO $ IO.lookupEnv "KEEP_WORKSPACE"
   ws <- H.evalIO $ IO.createTempDirectory systemTemp $ prefixPath <> "-test"
   H.annotate $ "Workspace: " <> ws
-  liftIO $ IO.writeFile (ws </> "module") callerModuleName
+  H.evalIO $ IO.writeFile (ws </> "module") callerModuleName
   f ws
   when (IO.os /= "mingw32" && maybeKeepWorkspace /= Just "1") $ do
-    H.evalIO $ IO.removeDirectoryRecursive ws
+    H.evalIO $ IO.removePathForcibly ws
 
 -- | Create a workspace directory which will exist for at least the duration of
 -- the supplied block.


### PR DESCRIPTION
When using `workspace` sometimes this error happens:
```
               ┏━━ test/cardano-testnet-test/Cardano/Testnet/Test/Gov/TreasuryGrowth.hs ━━━
            34 ┃ prop_check_if_treasury_is_growing :: H.Property
            35 ┃ prop_check_if_treasury_is_growing = H.integrationRetryWorkspace 0 "growing-treasury" $ \tempAbsBasePath' -> runWithDefaultWatchdog_ $ do
               ┃ │ Workspace: /private/tmp/tmp.qdp0MjaEhc/growing-treasury-0-test-4739cce29b79ea31
               ┃ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               ┃ │ ━━━ Exception (IOException) ━━━
               ┃ │ /private/tmp/tmp.qdp0MjaEhc/growing-treasury-0-test-4739cce29b79ea31/logs: removeDirectoryRecursive:removeContentsRecursive:removePathRecursive:removeContentsRecursive:removeDirectory: unsatisfied constraints (Directory not empty)
```
It's occurring randomly. This PR changes removal function to force remove the path, which should stop the failures.