### PR TITLE
Add missing `HasCallStack` to writeGoldenFile, reportGoldenFileMissing, checkAgainstGoldenFile

### DIFF
--- a/src/Hedgehog/Extras/Test/Golden.hs
+++ b/src/Hedgehog/Extras/Test/Golden.hs
@@ -58,22 +58,24 @@ recreateGoldenFiles = IO.unsafePerformIO $ do
   return $ value == Just "1"
 
 writeGoldenFile :: ()
+  => HasCallStack
   => MonadIO m
   => MonadTest m
   => FilePath
   -> String
   -> m ()
-writeGoldenFile goldenFile actualContent = do
+writeGoldenFile goldenFile actualContent = GHC.withFrozenCallStack $ do
   H.note_ $ "Creating golden file " <> goldenFile
   H.createDirectoryIfMissing_ (takeDirectory goldenFile)
   H.writeFile goldenFile actualContent
 
 reportGoldenFileMissing :: ()
+  => HasCallStack
   => MonadIO m
   => MonadTest m
   => FilePath
   -> m ()
-reportGoldenFileMissing goldenFile = do
+reportGoldenFileMissing goldenFile = GHC.withFrozenCallStack $ do
   H.note_ $ unlines
     [ "Golden file " <> goldenFile <> " does not exist."
     , "To create it, run with CREATE_GOLDEN_FILES=1."
@@ -82,12 +84,13 @@ reportGoldenFileMissing goldenFile = do
   H.failure
 
 checkAgainstGoldenFile :: ()
+  => HasCallStack
   => MonadIO m
   => MonadTest m
   => FilePath
   -> [String]
   -> m ()
-checkAgainstGoldenFile goldenFile actualLines = do
+checkAgainstGoldenFile goldenFile actualLines = GHC.withFrozenCallStack $ do
   referenceLines <- List.lines <$> H.readFile goldenFile
   let difference = getGroupedDiff actualLines referenceLines
   case difference of
@@ -95,7 +98,7 @@ checkAgainstGoldenFile goldenFile actualLines = do
     [Both{}] -> pure ()
     _        -> do
       H.note_ $ unlines
-        [ "Golden test failed against golden file: " <> goldenFile
+        [ "Golden test failed against the golden file."
         , "To recreate golden file, run with RECREATE_GOLDEN_FILES=1."
         ]
       failMessage callStack $ ppDiff difference


### PR DESCRIPTION
This PR adds `HasCallStack` constraint to few functions doing the comparisons between strings or files. This allows for reporting where the failure (the execution of e.g. `checkAgainstGoldenFile`) occured. The downside is that the information message about the need to regenerate the files is shown at the failure location instead at the end of the error log. Sample failure after this change:
```
            149 ┃   -- gov-state
            150 ┃   do
            151 ┃     -- to stdout
            152 ┃     execCli' execConfig [ eraName, "query", "gov-state" ]
                ┃     │ ━━━━ command ━━━━
                ┃     │ /home/mgalazyn/workspace/iohk/dist-newstyle/build/x86_64-linux/ghc-9.8.2/cardano-cli-8.23.1.0/x/cardano-cli/build/cardano-cli/cardano-cli conway query gov-state
            153 ┃       >>=
            154 ┃         (`H.diffVsGoldenFile`
                ┃         │ Reading file: test/cardano-testnet-test/files/golden/queries/govStateOut.json
                ┃         │ Golden test failed against golden file.
                ┃         │ To recreate golden file, run with RECREATE_GOLDEN_FILES=1.
                ┃         ^^^^^^^^^^^^^^^^^^^^^
                ┃         │ 656c656
                ┃         │ <         "tag": "NoPParamsUpdate"
                ┃         │ ---
                ┃         │ >         "tag": ""
            155 ┃             "test/cardano-testnet-test/files/golden/queries/govStateOut.json")
            156 ┃     -- to a file
            157 ┃     let govStateOutFile = work </> "gov-state-out.json"
            158 ┃     H.noteM_ $ execCli' execConfig [ eraName, "query", "gov-state", "--out-file", govStateOutFile]
            159 ┃     H.diffFileVsGoldenFile
            160 ┃       govStateOutFile
            161 ┃       "test/cardano-testnet-test/files/golden/queries/govStateOut.json"
            162 ┃
            163 ┃   -- drep-state
            164 ┃   do
            165 ┃     -- to stdout
            166 ┃     -- TODO: deserialize to a Haskell value when
            167 ┃     -- https://github.com/IntersectMBO/cardano-cli/issues/606 is tackled
            168 ┃     dreps :: Aeson.Value <- H.noteShowM $ execCliStdoutToJson execConfig [ eraName, "query", "drep-state", "--all-dreps"]
            169 ┃     assertArrayOfSize dreps 3
            170 ┃     -- to a file
            171 ┃     let drepStateOutFile = work </> "drep-state-out.json"
            172 ┃     H.noteM_ $ execCli' execConfig [ eraName, "query", "drep-state", "--all-dreps"
            173 ┃                                    , "--out-file", drepStateOutFile]
            174 ┃     _ :: Aeson.Value <- H.readJsonFileOk drepStateOutFile
            175 ┃     pure ()
            176 ┃
            177 ┃   H.success

            This failure can be reproduced by running:
            > recheckAt (Seed 17230671044673320290 2354375817147678641) "1:" CliQueries

        Use "--pattern '$NF ~ /CliQueries/' --hedgehog-replay '1: Seed 17230671044673320290 2354375817147678641'" to reproduce from the command-line.

```