### PR TITLE
Add `expectFailure` combinator

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -152,6 +152,7 @@ test-suite hedgehog-extras-test
   type:                 exitcode-stdio-1.0
 
   other-modules:        Hedgehog.Extras.Stock.IO.Network.PortSpec
+                        Hedgehog.Extras.Test.TestExpectFailure
                         Hedgehog.Extras.Test.TestWatchdogSpec
 
   build-tool-depends:   tasty-discover:tasty-discover

--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -90,7 +90,7 @@ module Hedgehog.Extras.Test.Base
 
 import           Control.Applicative (Applicative (..))
 import           Control.Monad (Functor (fmap), Monad (return, (>>=)), mapM_, unless, void, when)
-import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Catch (Handler (..), MonadCatch)
 import           Control.Monad.Morph (hoist)
 import           Control.Monad.Reader (MonadIO (..), MonadReader (ask))
 import           Control.Monad.Trans.Resource (MonadResource, ReleaseKey, register, runResourceT)
@@ -125,7 +125,6 @@ import           Text.Show (Show (show))
 import qualified Control.Concurrent as IO
 import qualified Control.Concurrent.STM as STM
 import           Control.Exception (IOException)
-import           Control.Monad.Catch (Handler (..))
 import qualified Control.Monad.Trans.Resource as IO
 import qualified Control.Retry as R
 import qualified Data.List as L
@@ -158,7 +157,7 @@ failMessage :: MonadTest m => CallStack -> String -> m a
 failMessage cs = failWithCustom cs Nothing
 
 -- | Invert the behavior of a property: success becomes failure and vice versa.
-expectFailure :: HasCallStack => H.TestT IO m -> H.PropertyT IO ()
+expectFailure :: (MonadTest m, MonadIO m, HasCallStack) => H.TestT IO a -> m ()
 expectFailure prop = GHC.withFrozenCallStack $ do
   (res, _) <- H.evalIO $ H.runTestT prop
   case res of

--- a/src/Hedgehog/Extras/Test/Base.hs
+++ b/src/Hedgehog/Extras/Test/Base.hs
@@ -159,11 +159,7 @@ failMessage cs = failWithCustom cs Nothing
 
 -- | Invert the behavior of a property: success becomes failure and vice versa.
 expectFailure :: (MonadTest m, MonadIO m, HasCallStack) => H.TestT IO a -> m ()
-expectFailure prop = GHC.withFrozenCallStack $ do
-  (res, _) <- H.evalIO $ H.runTestT prop
-  case res of
-    Left _ -> pure () -- Property failed so we succeed
-    _ -> H.failWith Nothing "Expected the test to fail but it passed" -- Property passed but we expected a failure
+expectFailure = GHC.withFrozenCallStack $ expectFailureWith (pure . const ())
 
 -- | Invert the behavior of a property: success becomes failure and vice versa.
 -- This function behaves like 'expectFailure' but it allows to check the failure

--- a/test/Hedgehog/Extras/Test/TestExpectFailure.hs
+++ b/test/Hedgehog/Extras/Test/TestExpectFailure.hs
@@ -1,0 +1,37 @@
+module Hedgehog.Extras.Test.TestExpectFailure where
+
+import           Prelude
+import           Hedgehog (property, Property, MonadTest, (===), success)
+import           Hedgehog.Extras.Test.Base (expectFailureWith, expectFailure)
+import           Hedgehog.Internal.Property (Failure (..), failWith)
+import           GHC.Stack (HasCallStack)
+import           Control.Monad.IO.Class (MonadIO)
+
+hprop_expect_always_fails_prop :: Property
+hprop_expect_always_fails_prop = property $ do
+  expectFailureWith failureCheck alwaysFailsProp
+  where
+    failureCheck :: (MonadTest m, HasCallStack) => Failure -> m ()
+    failureCheck (Failure _ reason _) =
+      reason === "This property always fails"
+
+    alwaysFailsProp :: (MonadTest m, HasCallStack) => m ()
+    alwaysFailsProp = failWith Nothing "This property always fails"
+
+hprop_bad_expect_always_fails_fails_prop :: Property
+hprop_bad_expect_always_fails_fails_prop = property $ do
+  expectFailure badExpectFailure
+  where
+    badExpectFailure :: (MonadIO m, MonadTest m, HasCallStack) => m ()
+    badExpectFailure = expectFailureWith badFailureCheck alwaysFailsProp
+
+    badFailureCheck :: (MonadTest m, HasCallStack) => Failure -> m ()
+    badFailureCheck (Failure _ reason _) =
+      reason === "This property sometimes fails"
+
+    alwaysFailsProp :: (MonadTest m, HasCallStack) => m ()
+    alwaysFailsProp = failWith Nothing "This property always fails"
+
+hprop_bad_expect_failure_fails_prop :: Property
+hprop_bad_expect_failure_fails_prop = property $ do
+  expectFailure (expectFailure success)


### PR DESCRIPTION
This PR adds a new combinator that when applied to a property it will invert its behaviour:
- If the property fails, the new property will pass
- If the property passes, the new property will fail

This is useful for writing negative tests

See the following PR for an example of usage: https://github.com/IntersectMBO/cardano-cli/pull/910

Based on equivalent QuickCheck combinator: https://hackage.haskell.org/package/QuickCheck-2.15.0.1/docs/Test-QuickCheck.html#v:expectFailure