### PR TITLE
New version hedgehog-extras-0.7.0.0

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.4
 
 name:                   hedgehog-extras
-version:                0.6.5.1
+version:                0.7.0.0
 synopsis:               Supplemental library for hedgehog
 description:            Supplemental library for hedgehog.
 category:               Test


### PR DESCRIPTION
0.6.5.1 is deprecated because it contains breaking changes, so it shouldn't be a minor version bump. This is just a version bump aligning with Haskell PVP.