### PR TITLE
Fix and modernize the Haskell CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -134,10 +134,10 @@ jobs:
 
       - name: Check if cabal project is sane
         run: |
-          PROJECT_DIR=$PWD
-          mkdir -p $PROJECT_DIR/build/sdist
+          PROJECT_DIR="$PWD"
+          mkdir -p "$PROJECT_DIR/build/sdist"
           for i in $(git ls-files | grep '\.cabal'); do
-            cd $PROJECT_DIR && cd `dirname $i`
+            cd "$PROJECT_DIR" && cd "$(dirname $i)"
             cabal check
           done
 
@@ -181,10 +181,10 @@ jobs:
 
       - name: Create source distribution
         run: |
-          PROJECT_DIR=$PWD
-          mkdir -p $PROJECT_DIR/build/sdist
+          PROJECT_DIR="$PWD"
+          mkdir -p "$PROJECT_DIR/build/sdist"
           for i in $(git ls-files | grep '\.cabal'); do
-            cd $PROJECT_DIR && cd `dirname $i`
+            cd "$PROJECT_DIR" && cd "$(dirname $i)"
             cabal v2-sdist -o $PROJECT_DIR/build/sdist
           done;
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,127 +1,141 @@
-name: Binaries
-
-defaults:
-  run:
-    shell: bash
+name: Haskell CI
 
 on:
+  pull_request:
   push:
+    # we need this to populate cache for `main` branch to make it available to the child branches, see
+    # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
     branches:
       - 'main'
     tags:
       - "v*"
-  pull_request:
+  # GH caches are removed when not accessed within 7 days - this schedule runs the job every 6 days making
+  # sure that we always have some caches on master
+  schedule:
+    - cron: '0 0 */6 * *'
 
 jobs:
   build:
-    name: "Build Haskell"
-    runs-on: ${{ matrix.os }}
-    environment: cabal-cache
-
-    env:
-      # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-05-01-1"
+    runs-on: ${{ matrix.sys.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.2.8", "9.6.5", "9.8.2", "9.10.1"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        cabal: ["3.10.3.0"]
+        ghc: ["9.6", "9.10", "9.12"]
+        cabal: ["3.14"]
+        sys:
+          - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
+          - { os: ubuntu-latest, shell: bash }
+
+    defaults:
+      run:
+        shell: ${{ matrix.sys.shell }}
+
+    env:
+      # Modify this value to "invalidate" the cabal cache.
+      CABAL_CACHE_VERSION: "2024-05-01-1"
+      # these two are msys2 env vars, they have no effect on non-msys2 installs.
+      MSYS2_PATH_TYPE: inherit
+      MSYSTEM: MINGW64
+
+    concurrency:
+      group: >
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.sys.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v3
+    - name: Concurrency group
+      run: >
+        echo
+        a+${{ github.event_name }}
+        b+${{ github.workflow_ref }}
+        c+${{ github.job }}
+        d+${{ matrix.ghc }}
+        e+${{ matrix.cabal }}
+        f+${{ matrix.sys.os }}
+        g+${{ (startsWith(github.ref, 'refs/heads/gh-readonly-queue/') && github.run_id) || github.event.pull_request.number || github.ref }}
 
-      - name: Setup Haskell
-        uses: haskell-actions/setup@v2
-        id: setup-haskell
-        with:
-          ghc-version: ${{ matrix.ghc }}
-          cabal-version: ${{ matrix.cabal }}
+    - name: Install Haskell
+      uses: input-output-hk/actions/haskell@latest
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
 
-      - name: Configure update
-        run: cabal update
+    - name: Install system dependencies
+      uses: input-output-hk/actions/base@latest
+      with:
+        use-sodium-vrf: true # default is true
 
-      - name: Configure project
-        run: |
-          cabal configure --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+
-          cabal build all --dry-run
+    - uses: actions/checkout@v4
 
-      # For users who fork cardano-node and want to define a writable cache, then can set up their own
-      # S3 bucket then define in their forked repository settings the following secrets:
-      #
-      #   AWS_ACCESS_KEY_ID
-      #   AWS_SECRET_ACCESS_KEY
-      #   BINARY_CACHE_URI
-      #   BINARY_CACHE_REGION
-      - name: Cabal cache over S3
-        uses: action-works/cabal-cache-s3@v1
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        with:
-          region: ${{ secrets.BINARY_CACHE_REGION }}
-          dist-dir: dist-newstyle
-          store-path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          threads: 16
-          archive-uri: ${{ secrets.BINARY_CACHE_URI }}/${{ env.CABAL_CACHE_VERSION }}/${{ runner.os }}
-          skip: "${{ secrets.BINARY_CACHE_URI == '' }}"
+    - name: Cabal update
+      run: cabal update
 
-      # It's important to ensure that people who fork this repository can not only successfully build in
-      # CI by default, but also have meaning cabal store caching.
-      #
-      # Because syncing with S3 requires credentials, we cannot rely on S3 for this. For this reason a
-      # https fallback is used. The https server mirrors the content of the S3 bucket. The https cabal
-      # store archive is read-only for security reasons.
-      #
-      # Users who fork this repository who want to have a writable cabal store archive are encouraged
-      # to set up their own S3 bucket.
-      - name: Cabal cache over HTTPS
-        uses: action-works/cabal-cache-s3@v1
-        with:
-          dist-dir: dist-newstyle
-          store-path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          threads: 16
-          archive-uri: https://iohk.cache.haskellworks.io/${{ env.CABAL_CACHE_VERSION }}/${{ runner.os }}
-          skip: "${{ secrets.BINARY_CACHE_URI != '' }}"
-          enable-save: false
+    # A dry run `build all` operation does *NOT* download anything, it just looks at the package
+    # indices to generate an install plan.
+    - name: Build dry run
+      run: cabal build all --enable-tests --dry-run --minimize-conflict-set
 
-      - name: Build dependencies
-        run: cabal build --dependencies-only --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+
+    # From the install plan we generate a dependency list.
+    - name: Record dependencies
+      id: record-deps
+      run: |
+        cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(.style != "local") | .id' | sort | uniq > dependencies.txt
 
-      - name: Build
-        run: cabal build all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+
+    # Use a fresh cache each month
+    - name: Store month number as environment variable used in cache version
+      run:  echo "MONTHNUM=$(date -u '+%m')" >> $GITHUB_ENV
 
-      - name: Test
-        run: cabal test all --enable-tests --enable-benchmarks --write-ghc-environment-files=ghc8.4.4+
+    # From the dependency list we restore the cached dependencies.
+    # We use the hash of `dependencies.txt` as part of the cache key because that will be stable
+    # until the `index-state` values in the `cabal.project` file changes.
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key:
+          cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
+        # try to restore previous cache from this month if there's no cache for the dependencies set
+        restore-keys: |
+          cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-
 
-      - name: Compress Binary
-        id: compress_binary
-        env:
-          GHC_VER: ${{ matrix.ghc }}
-        run: |
-          cat dist-newstyle/cache/plan.json | jq -r '
-              ."install-plan"[]
-            | select(."component-name")
-            | select(.style == "local")
-            | select(."component-name" | startswith("exe:"))
-            | ."bin-file"' > release-files.txt
+    # Now we install the dependencies. If the cache was found and restored in the previous step,
+    # this should be a no-op, but if the cache key was not found we need to build stuff so we can
+    # cache it for the next step.
+    - name: Install dependencies
+      run: cabal build all --enable-tests --only-dependencies
 
-          mkdir -p artifacts
+    # Always store the cabal cache.
+    # This can fail (benign failure) if there is already a hash at that key.
+    - name: Cache Cabal store
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
+        key:
+          ${{ steps.cache.outputs.cache-primary-key }}
 
-          echo "Publishing the following files:"
+    # Now we build.
+    - name: Build all
+      run: cabal build all --enable-tests
 
-          while IFS= read -r line; do
-            echo "  $line"
-            cp "$line" artifacts
-          done < release-files.txt
-
-          tar zcvf artifacts-${{ runner.OS }}-${{ matrix.ghc }}.tar.gz artifacts
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-${{ runner.OS }}-${{ matrix.ghc }}.tar.gz
-          path: artifacts-${{ runner.OS }}-${{ matrix.ghc }}.tar.gz
+    - name: Run tests
+      env:
+        TMPDIR: ${{ runner.temp }}
+        TMP: ${{ runner.temp }}
+        KEEP_WORKSPACE: 1
+      run: cabal test all --enable-tests --test-show-details=direct
 
   check:
     needs: build

--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -19,7 +19,7 @@ source-repository head
 common aeson                        { build-depends: aeson                            >= 2.0.0.0                  }
 common aeson-pretty                 { build-depends: aeson-pretty                     >= 0.8.5                    }
 common async                        { build-depends: async                                                        }
-common base                         { build-depends: base                             >= 4.12       && < 4.21     }
+common base                         { build-depends: base                             >= 4.12       && < 4.22     }
 common bytestring                   { build-depends: bytestring                                                   }
 common deepseq                      { build-depends: deepseq                                                      }
 common Diff                         { build-depends: Diff                                                         }


### PR DESCRIPTION
## Context

A number of PRs are blocked on the CI being outdated:

* https://github.com/input-output-hk/hedgehog-extras/pull/77
* https://github.com/input-output-hk/hedgehog-extras/pull/72

They fail on MacOS (see e.g. [this pipeline run](https://github.com/input-output-hk/hedgehog-extras/actions/runs/13927814131/job/38976889986?pr=77)) with:

```shell
Run action-works/cabal-cache-s3@v1
skip: false
Extracting parameters
Building options
Saving state
Installing cabal-cache
Downloading: https://github.com/haskell/cabal-cache/releases/latest/download/cabal-cache-x86_64-darwin.tar.gz
Error: Unexpected HTTP response: 404
```

This PR aims to fix that by modernizing this CI, by aligning it with `cardano-cli` and `cadano-api` CIs

## How to trust this PR

1. Look at a run of the new pipeline: https://github.com/input-output-hk/hedgehog-extras/actions/runs/13942970198/job/39023629825?pr=78
1. See that it executes the same tests as an old pipeline: https://github.com/input-output-hk/hedgehog-extras/actions/runs/12481947498/job/34835265595

* Observe that I only changed the `build` part of the pipeline
* The rest of the pipeline (release) is unchanged

See that the CI correctly uses the cache: 

![image](https://github.com/user-attachments/assets/2b43ad81-9dad-4efe-92b9-6c4e07948f81)