### PR TITLE
Fix haddock for `threadDelay`

### DIFF
--- a/src/Hedgehog/Extras/Test/Concurrent.hs
+++ b/src/Hedgehog/Extras/Test/Concurrent.hs
@@ -94,7 +94,7 @@ import           GHC.Stack
 import           Hedgehog
 import qualified Hedgehog as H
 
--- | Delay the thread by 'n' milliseconds.
+-- | Delay the thread by 'n' microseconds.
 threadDelay :: (HasCallStack, MonadTest m, MonadIO m) => Int -> m ()
 threadDelay n = GHC.withFrozenCallStack . H.evalIO $ IO.threadDelay n
 


### PR DESCRIPTION
# Context

`threadDelay` calls `Control.Concurrent.threadDelay`, which takes an argument in microseconds, instead of milliseconds as the documentation specified. This commit fixes that typo.

# How to trust this PR

Have a look at the [documentation](https://hackage.haskell.org/package/base-4.21.0.0/docs/Control-Concurrent.html#v:threadDelay) for `Control.Concurrent.threadDelay`, notice that the argument is treated as a number of microseconds.

Additionally, one can call `H.threadDelay 10_000` and `H.threadDelay 10_000_000`, and notice that only the second call delays the thread for 10 seconds.