### PR TITLE
chore: add upper bounds to dependencies for PVP compliance

### DIFF
--- a/hedgehog-extras.cabal
+++ b/hedgehog-extras.cabal
@@ -16,52 +16,52 @@ source-repository head
   type:                 git
   location:             https://github.com/input-output-hk/hedgehog-extras
 
-common aeson                        { build-depends: aeson                            >= 2.0.0.0                  }
-common aeson-pretty                 { build-depends: aeson-pretty                     >= 0.8.5                    }
-common async                        { build-depends: async                                                        }
-common base                         { build-depends: base                             >= 4.12       && < 4.22     }
-common bytestring                   { build-depends: bytestring                                                   }
-common containers                   { build-depends: containers                                                   }
-common deepseq                      { build-depends: deepseq                                                      }
-common Diff                         { build-depends: Diff                                                         }
-common directory                    { build-depends: directory                                                    }
-common exceptions                   { build-depends: exceptions                                                   }
-common filepath                     { build-depends: filepath                                                     }
-common generic-lens                 { build-depends: generic-lens                                                 }
-common hedgehog                     { build-depends: hedgehog                                                     }
-common hedgehog-quickcheck          { build-depends: hedgehog-quickcheck                                          }
-common http-conduit                 { build-depends: http-conduit                                                 }
-common hw-prelude                   { build-depends: hw-prelude                                                   }
-common lifted-async                 { build-depends: lifted-async                                                 }
-common lifted-base                  { build-depends: lifted-base                                                  }
-common microlens                    { build-depends: microlens                                                    }
-common mmorph                       { build-depends: mmorph                                                       }
-common monad-control                { build-depends: monad-control                                                }
-common mtl                          { build-depends: mtl                                                          }
-common network                      { build-depends: network                                                      }
-common process                      { build-depends: process                                                      }
-common resourcet                    { build-depends: resourcet                                                    }
-common retry                        { build-depends: retry                             >= 0.9                     }
-common stm                          { build-depends: stm                                                          }
-common tar                          { build-depends: tar                              ^>= 0.6                     }
-common tasty                        { build-depends: tasty                                                        }
-common tasty-discover               { build-depends: tasty-discover                   >= 5.0.2                    }
-common tasty-hedgehog               { build-depends: tasty-hedgehog                                               }
-common tasty-quickcheck             { build-depends: tasty-quickcheck                                             }
-common temporary                    { build-depends: temporary                                                    }
-common text                         { build-depends: text                                                         }
-common time                         { build-depends: time                             >= 1.9.1                    }
-common transformers                 { build-depends: transformers                                                 }
-common transformers-base            { build-depends: transformers-base                                            }
-common unliftio                     { build-depends: unliftio                                                     }
-common yaml                         { build-depends: yaml                                                         }
-common zlib                         { build-depends: zlib                                                         }
+common aeson                        { build-depends: aeson                            >= 2.0.0.0 && < 2.3         }
+common aeson-pretty                 { build-depends: aeson-pretty                     >= 0.8.5   && < 0.9         }
+common async                        { build-depends: async                                          < 2.3         }
+common base                         { build-depends: base                             >= 4.12    && < 4.22        }
+common bytestring                   { build-depends: bytestring                                     < 0.13        }
+common containers                   { build-depends: containers                                     < 0.8         }
+common deepseq                      { build-depends: deepseq                                        < 1.6         }
+common Diff                         { build-depends: Diff                                           < 1.1         }
+common directory                    { build-depends: directory                                      < 1.4         }
+common exceptions                   { build-depends: exceptions                                     < 0.11        }
+common filepath                     { build-depends: filepath                                       < 1.6         }
+common generic-lens                 { build-depends: generic-lens                                   < 2.3         }
+common hedgehog                     { build-depends: hedgehog                                       < 1.6         }
+common hedgehog-quickcheck          { build-depends: hedgehog-quickcheck                            < 0.2         }
+common http-conduit                 { build-depends: http-conduit                                   < 2.4         }
+common hw-prelude                   { build-depends: hw-prelude                                     < 0.1         }
+common lifted-async                 { build-depends: lifted-async                                   < 0.11        }
+common lifted-base                  { build-depends: lifted-base                                    < 0.3         }
+common microlens                    { build-depends: microlens                                      < 0.5         }
+common mmorph                       { build-depends: mmorph                                         < 1.3         }
+common monad-control                { build-depends: monad-control                                  < 1.1         }
+common mtl                          { build-depends: mtl                                            < 2.4         }
+common network                      { build-depends: network                                        < 3.3         }
+common process                      { build-depends: process                                        < 1.7         }
+common resourcet                    { build-depends: resourcet                                      < 1.4         }
+common retry                        { build-depends: retry                            >= 0.9     && < 0.10        }
+common stm                          { build-depends: stm                                            < 2.6         }
+common tar                          { build-depends: tar                              >= 0.6     && < 0.7         }
+common tasty                        { build-depends: tasty                                          < 1.6         }
+common tasty-discover               { build-depends: tasty-discover                   >= 5.0.2   && < 5.2         }
+common tasty-hedgehog               { build-depends: tasty-hedgehog                                 < 1.5         }
+common tasty-quickcheck             { build-depends: tasty-quickcheck                               < 0.11        }
+common temporary                    { build-depends: temporary                                      < 1.4         }
+common text                         { build-depends: text                                           < 2.2         }
+common time                         { build-depends: time                             >= 1.9.1   && < 1.15        }
+common transformers                 { build-depends: transformers                                   < 0.7         }
+common transformers-base            { build-depends: transformers-base                              < 0.5         }
+common unliftio                     { build-depends: unliftio                                       < 0.3         }
+common yaml                         { build-depends: yaml                                           < 0.12        }
+common zlib                         { build-depends: zlib                                           < 0.8         }
 
 common hedgehog-extras              { build-depends: hedgehog-extras                                              }
 
 common Win32
   if os(windows)
-    build-depends:      Win32   >= 2.5.4.1
+    build-depends:      Win32   >= 2.5.4.1 && < 2.15
 
 common project-config
   default-language:     Haskell2010


### PR DESCRIPTION
## Summary

Add upper bounds to all library dependencies to comply with Package Versioning Policy (PVP). This resolves the missing upper bounds warnings that were flagged during Hackage upload.

## Changes

- Added upper bounds to 39 dependencies including aeson, async, containers, hedgehog, network, and others
- Preserved existing lower bounds where present  
- Updated Win32 dependency with upper bound for Windows builds

## Details

The bounds are based on the versions in the current freeze file and follow PVP guidelines to prevent breakage from major/minor version updates while allowing patch releases.

This ensures the package will build reliably for users and prevents compatibility issues with future dependency updates.

## Testing

- [x] Package builds successfully with new bounds
- [x] All tests continue to pass
- [x] Bounds are based on current freeze file versions